### PR TITLE
Adding a test and feat when RemoteAccountModel throws

### DIFF
--- a/lib/data/usecases/authentication/remote_authentication.dart
+++ b/lib/data/usecases/authentication/remote_authentication.dart
@@ -8,20 +8,17 @@ class RemoteAuthentication implements Authentication {
   final HttpClient httpClient;
   final String url;
 
-  RemoteAuthentication({
-    required this.httpClient,
-    required this.url
-  });
+  RemoteAuthentication({required this.httpClient, required this.url});
 
   Future<AccountEntity> auth(AuthenticationParams params) async {
     final body = RemoteAuthenticationParams.fromDomain(params).toJson();
     try {
       final httpResponse = await httpClient.request(url: url, method: 'post', body: body);
       return RemoteAccountModel.fromJson(httpResponse).toEntity();
-    } on HttpError catch(error) {
-      throw error == HttpError.unauthorized
-        ? DomainError.invalidCredentials
-        : DomainError.unexpected;
+    } on HttpError catch (error) {
+      throw error == HttpError.unauthorized ? DomainError.invalidCredentials : DomainError.unexpected;
+    } catch (error) {
+      throw DomainError.unexpected;
     }
   }
 }
@@ -30,13 +27,9 @@ class RemoteAuthenticationParams {
   final String email;
   final String password;
 
-  RemoteAuthenticationParams({
-    required this.email,
-    required this.password
-  });
+  RemoteAuthenticationParams({required this.email, required this.password});
 
-  factory RemoteAuthenticationParams.fromDomain(AuthenticationParams params) => 
-    RemoteAuthenticationParams(email: params.email, password: params.secret);
+  factory RemoteAuthenticationParams.fromDomain(AuthenticationParams params) => RemoteAuthenticationParams(email: params.email, password: params.secret);
 
   Map toJson() => {'email': email, 'password': password};
 }

--- a/test/data/usecases/authentication/remote_authentication_test.dart
+++ b/test/data/usecases/authentication/remote_authentication_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_test/flutter_test.dart';
 import 'package:fordev/domain/helpers/helpers.dart';
 import 'package:fordev/domain/usecases/usecases.dart';
 import 'package:fordev/data/http/http.dart';
@@ -30,11 +31,7 @@ void main() {
   test('Should call HttpClient with correct values', () async {
     await sut.auth(params);
 
-    verify(() => httpClient.request(
-      url: url,
-      method: 'post',
-      body: {'email': params.email, 'password': params.secret}
-    ));
+    verify(() => httpClient.request(url: url, method: 'post', body: {'email': params.email, 'password': params.secret}));
   });
 
   test('Should throw UnexpectedError if HttpClient returns 400', () async {
@@ -80,6 +77,12 @@ void main() {
 
     final future = sut.auth(params);
 
+    expect(future, throwsA(DomainError.unexpected));
+  });
+
+  test('Should throw UnexpectedError if RemoteAccountModel throws when HttpClient returns 204', () async {
+    httpClient.mockRequest(null);
+    final future = sut.auth(params);
     expect(future, throwsA(DomainError.unexpected));
   });
 }


### PR DESCRIPTION
This pull contains a feat and test when HttpClient returns 204 to RemoteAuthentication.
When RemoteAuthentication calls RemoteAccountModel with null, this throws an Error that don't catch by try/catch block in RemoteAuthentication.
This pull request try fix it.